### PR TITLE
forgo/forgo#59: Updated for the final release of the new component API

### DIFF
--- a/routing/package-lock.json
+++ b/routing/package-lock.json
@@ -7,8 +7,8 @@
       "name": "forgo-examples",
       "license": "MIT",
       "dependencies": {
-        "forgo": "^3.1.0",
-        "forgo-router": "1.0.0"
+        "forgo": "^3.2.0-beta.0",
+        "forgo-router": "1.3.0-beta.0"
       },
       "devDependencies": {
         "@babel/core": "^7.12.10",
@@ -3571,22 +3571,17 @@
       }
     },
     "node_modules/forgo": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/forgo/-/forgo-3.1.0.tgz",
-      "integrity": "sha512-u5QZ9vnRJoIcZelwZ3kYzJ+jrbh+lvx1Ixp5+GXxE2I3/AVdgK5IeL1hGgi3rBfhlxKjcs2fqKPycOED8FT5SQ=="
+      "version": "3.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/forgo/-/forgo-3.2.0-beta.0.tgz",
+      "integrity": "sha512-JSLvM3Xwa++R2Y09b9TIoPueITRoF0pLQuXTZWoTBZ/fBqVbrIxlaEOBF+q9YTQbE97Cxag0rC1CvWwcjevWoA=="
     },
     "node_modules/forgo-router": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/forgo-router/-/forgo-router-1.0.0.tgz",
-      "integrity": "sha512-mZwB6wj/9N1ERB3D5fp2BZnwt8D43u3uTgWn/BigfHQAAhIsN7Z1mz9llm1e/BSaLr3SF+nZSWZunb4DRLdr2Q==",
-      "dependencies": {
-        "forgo": "~1.0.0"
+      "version": "1.3.0-beta.0",
+      "resolved": "https://registry.npmjs.org/forgo-router/-/forgo-router-1.3.0-beta.0.tgz",
+      "integrity": "sha512-JYXqxJ+Dvw122ignwRXOQrn+BhxxbyuTMDJp75bAysbiPYm3SRDqPl0LUXtbpxQktOkGkEIYu3NZm+6mrobjHQ==",
+      "peerDependencies": {
+        "forgo": "^3.2.0-beta.0"
       }
-    },
-    "node_modules/forgo-router/node_modules/forgo": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/forgo/-/forgo-1.0.2.tgz",
-      "integrity": "sha512-SAbU8qfJVJSOs9UeY5D5lzHbFEn+u7s2890TdUL7yUrA64Xfcsy2jw/Q4982APZUaCk4q21kPcevdHF2vHTxPQ=="
     },
     "node_modules/forwarded": {
       "version": "0.1.2",
@@ -11174,24 +11169,15 @@
       "dev": true
     },
     "forgo": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/forgo/-/forgo-3.1.0.tgz",
-      "integrity": "sha512-u5QZ9vnRJoIcZelwZ3kYzJ+jrbh+lvx1Ixp5+GXxE2I3/AVdgK5IeL1hGgi3rBfhlxKjcs2fqKPycOED8FT5SQ=="
+      "version": "3.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/forgo/-/forgo-3.2.0-beta.0.tgz",
+      "integrity": "sha512-JSLvM3Xwa++R2Y09b9TIoPueITRoF0pLQuXTZWoTBZ/fBqVbrIxlaEOBF+q9YTQbE97Cxag0rC1CvWwcjevWoA=="
     },
     "forgo-router": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/forgo-router/-/forgo-router-1.0.0.tgz",
-      "integrity": "sha512-mZwB6wj/9N1ERB3D5fp2BZnwt8D43u3uTgWn/BigfHQAAhIsN7Z1mz9llm1e/BSaLr3SF+nZSWZunb4DRLdr2Q==",
-      "requires": {
-        "forgo": "~1.0.0"
-      },
-      "dependencies": {
-        "forgo": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/forgo/-/forgo-1.0.2.tgz",
-          "integrity": "sha512-SAbU8qfJVJSOs9UeY5D5lzHbFEn+u7s2890TdUL7yUrA64Xfcsy2jw/Q4982APZUaCk4q21kPcevdHF2vHTxPQ=="
-        }
-      }
+      "version": "1.3.0-beta.0",
+      "resolved": "https://registry.npmjs.org/forgo-router/-/forgo-router-1.3.0-beta.0.tgz",
+      "integrity": "sha512-JYXqxJ+Dvw122ignwRXOQrn+BhxxbyuTMDJp75bAysbiPYm3SRDqPl0LUXtbpxQktOkGkEIYu3NZm+6mrobjHQ==",
+      "requires": {}
     },
     "forwarded": {
       "version": "0.1.2",

--- a/routing/package.json
+++ b/routing/package.json
@@ -2,8 +2,8 @@
   "name": "forgo-examples",
   "private": true,
   "dependencies": {
-    "forgo": "^3.1.0",
-    "forgo-router": "1.0.0"
+    "forgo": "^3.2.0-beta.0",
+    "forgo-router": "1.3.0-beta.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",

--- a/routing/src/index.tsx
+++ b/routing/src/index.tsx
@@ -1,5 +1,7 @@
-import { mount } from "forgo";
+import * as forgo from "forgo";
+import { mount, Component } from "forgo";
 import { Router, matchUrl, matchExactUrl, Link } from "forgo-router";
+import type { ForgoNewComponentCtor } from "forgo";
 
 type Customer = {
   id: number;
@@ -13,8 +15,8 @@ const customers = [
   { id: 3, name: "Deepsta", age: 42 },
 ];
 
-function App() {
-  return {
+const App: ForgoNewComponentCtor = () => {
+  return new Component({
     render() {
       return (
         <Router>
@@ -25,11 +27,11 @@ function App() {
         </Router>
       );
     },
-  };
-}
+  });
+};
 
-function Home() {
-  return {
+const Home: ForgoNewComponentCtor = () => {
+  return new Component({
     render() {
       return (
         <div>
@@ -46,11 +48,11 @@ function Home() {
         </div>
       );
     },
-  };
-}
+  });
+};
 
-function Customers() {
-  return {
+const Customers: ForgoNewComponentCtor = () => {
+  return new Component({
     render() {
       return (
         <div>
@@ -66,15 +68,15 @@ function Customers() {
         </div>
       );
     },
-  };
-}
-
-type CustomersProps = {
-  customers: Customer[];
+  });
 };
 
-export function CustomerList(props: CustomersProps) {
-  return {
+interface CustomersProps {
+  customers: Customer[];
+}
+
+export const CustomerList: ForgoNewComponentCtor<CustomersProps> = () => {
+  return new Component({
     render(props: CustomersProps) {
       return (
         <div>
@@ -91,15 +93,17 @@ export function CustomerList(props: CustomersProps) {
         </div>
       );
     },
-  };
-}
-
-type CustomerDetailsProps = {
-  id: string;
+  });
 };
 
-export function CustomerDetails(props: CustomerDetailsProps) {
-  return {
+interface CustomerDetailsProps {
+  id: string;
+}
+
+export const CustomerDetails: ForgoNewComponentCtor<CustomerDetailsProps> = (
+  props
+) => {
+  return new Component({
     render(props: CustomerDetailsProps) {
       const customer = customers.find((c) => c.id.toString() === props.id);
       return (
@@ -116,11 +120,11 @@ export function CustomerDetails(props: CustomerDetailsProps) {
         </div>
       );
     },
-  };
-}
+  });
+};
 
-export function AboutPage() {
-  return {
+export const AboutPage: ForgoNewComponentCtor = () => {
+  return new Component({
     render() {
       return (
         <div>
@@ -129,8 +133,8 @@ export function AboutPage() {
         </div>
       );
     },
-  };
-}
+  });
+};
 
 function ready(fn: any) {
   if (document.readyState != "loading") {

--- a/routing/tsconfig.json
+++ b/routing/tsconfig.json
@@ -9,8 +9,9 @@
     "allowSyntheticDefaultImports": true,
     "sourceMap": true,
     "strict": true,
-    "jsx": "react-jsx",
-    "jsxImportSource": "forgo"
+    "jsx": "react",
+    "jsxFactory": "forgo.createElement",
+    "jsxFragmentFactory": "forgo.Fragment"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/timer/package-lock.json
+++ b/timer/package-lock.json
@@ -7,7 +7,7 @@
       "name": "forgo-examples",
       "license": "MIT",
       "dependencies": {
-        "forgo": "^3.1.0"
+        "forgo": "^3.2.0-beta.0"
       },
       "devDependencies": {
         "@babel/core": "^7.12.10",
@@ -3570,9 +3570,9 @@
       }
     },
     "node_modules/forgo": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/forgo/-/forgo-3.1.0.tgz",
-      "integrity": "sha512-u5QZ9vnRJoIcZelwZ3kYzJ+jrbh+lvx1Ixp5+GXxE2I3/AVdgK5IeL1hGgi3rBfhlxKjcs2fqKPycOED8FT5SQ=="
+      "version": "3.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/forgo/-/forgo-3.2.0-beta.0.tgz",
+      "integrity": "sha512-JSLvM3Xwa++R2Y09b9TIoPueITRoF0pLQuXTZWoTBZ/fBqVbrIxlaEOBF+q9YTQbE97Cxag0rC1CvWwcjevWoA=="
     },
     "node_modules/forwarded": {
       "version": "0.1.2",
@@ -11160,9 +11160,9 @@
       "dev": true
     },
     "forgo": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/forgo/-/forgo-3.1.0.tgz",
-      "integrity": "sha512-u5QZ9vnRJoIcZelwZ3kYzJ+jrbh+lvx1Ixp5+GXxE2I3/AVdgK5IeL1hGgi3rBfhlxKjcs2fqKPycOED8FT5SQ=="
+      "version": "3.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/forgo/-/forgo-3.2.0-beta.0.tgz",
+      "integrity": "sha512-JSLvM3Xwa++R2Y09b9TIoPueITRoF0pLQuXTZWoTBZ/fBqVbrIxlaEOBF+q9YTQbE97Cxag0rC1CvWwcjevWoA=="
     },
     "forwarded": {
       "version": "0.1.2",

--- a/timer/package.json
+++ b/timer/package.json
@@ -2,7 +2,7 @@
   "name": "forgo-examples",
   "private": true,
   "dependencies": {
-    "forgo": "^3.1.0"
+    "forgo": "^3.2.0-beta.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",

--- a/timer/src/index.tsx
+++ b/timer/src/index.tsx
@@ -1,23 +1,24 @@
-import { mount, rerender, ForgoRenderArgs } from "forgo";
+import * as forgo from "forgo";
+import { mount, rerender, Component } from "forgo";
+import type { ForgoNewComponentCtor } from "forgo";
 
 /*
   A timer component
 */
-export function Timer() {
+export const Timer: ForgoNewComponentCtor = () => {
   let seconds = 0;
 
-  return {
-    render(props: any, args: ForgoRenderArgs) {
+  return new Component({
+    render(_props, component) {
       setTimeout(() => {
         seconds++;
-        rerender(args.element);
+        component.update();
       }, 1000);
 
       return <div>{seconds} secs have elapsed...</div>;
     },
-  };
-}
-
+  });
+};
 
 window.addEventListener("load", () => {
   mount(<Timer />, document.getElementById("root"));

--- a/timer/tsconfig.json
+++ b/timer/tsconfig.json
@@ -9,8 +9,9 @@
     "allowSyntheticDefaultImports": true,
     "sourceMap": true,
     "strict": true,
-    "jsx": "react-jsx",
-    "jsxImportSource": "forgo"
+    "jsx": "react",
+    "jsxFactory": "forgo.createElement",
+    "jsxFragmentFactory": "forgo.Fragment"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/todos/package-lock.json
+++ b/todos/package-lock.json
@@ -7,7 +7,7 @@
       "name": "forgo-examples",
       "license": "MIT",
       "dependencies": {
-        "forgo": "^3.1.0"
+        "forgo": "^3.2.0-beta.0"
       },
       "devDependencies": {
         "@babel/core": "^7.12.10",
@@ -3570,9 +3570,9 @@
       }
     },
     "node_modules/forgo": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/forgo/-/forgo-3.1.0.tgz",
-      "integrity": "sha512-u5QZ9vnRJoIcZelwZ3kYzJ+jrbh+lvx1Ixp5+GXxE2I3/AVdgK5IeL1hGgi3rBfhlxKjcs2fqKPycOED8FT5SQ=="
+      "version": "3.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/forgo/-/forgo-3.2.0-beta.0.tgz",
+      "integrity": "sha512-JSLvM3Xwa++R2Y09b9TIoPueITRoF0pLQuXTZWoTBZ/fBqVbrIxlaEOBF+q9YTQbE97Cxag0rC1CvWwcjevWoA=="
     },
     "node_modules/forwarded": {
       "version": "0.1.2",
@@ -11160,9 +11160,9 @@
       "dev": true
     },
     "forgo": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/forgo/-/forgo-3.1.0.tgz",
-      "integrity": "sha512-u5QZ9vnRJoIcZelwZ3kYzJ+jrbh+lvx1Ixp5+GXxE2I3/AVdgK5IeL1hGgi3rBfhlxKjcs2fqKPycOED8FT5SQ=="
+      "version": "3.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/forgo/-/forgo-3.2.0-beta.0.tgz",
+      "integrity": "sha512-JSLvM3Xwa++R2Y09b9TIoPueITRoF0pLQuXTZWoTBZ/fBqVbrIxlaEOBF+q9YTQbE97Cxag0rC1CvWwcjevWoA=="
     },
     "forwarded": {
       "version": "0.1.2",

--- a/todos/package.json
+++ b/todos/package.json
@@ -2,7 +2,7 @@
   "name": "forgo-examples",
   "private": true,
   "dependencies": {
-    "forgo": "^3.1.0"
+    "forgo": "^3.2.0-beta.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",

--- a/todos/src/index.tsx
+++ b/todos/src/index.tsx
@@ -1,18 +1,18 @@
-import { mount, rerender, ForgoRenderArgs } from "forgo";
+import * as forgo from "forgo";
+import { mount, rerender, Component } from "forgo";
+import type { ForgoNewComponentCtor } from "forgo";
 
 /*
   The main Todo List component
 */
-type TodoListProps = {};
-
-export function TodoList(props: TodoListProps) {
+export const TodoList: ForgoNewComponentCtor = () => {
   let todos: string[] = [];
 
-  return {
-    render(props: TodoListProps, args: ForgoRenderArgs) {
+  return new Component({
+    render(_props, component) {
       function onTodoAdd(text: string) {
         todos.push(text);
-        rerender(args.element);
+        component.update();
       }
 
       return (
@@ -27,51 +27,53 @@ export function TodoList(props: TodoListProps) {
         </div>
       );
     },
-  };
-}
+  });
+};
 
 /*
   Display a Todo list item
 */
-type TodoListItemProps = {
+interface TodoListItemProps {
   text: string;
-};
+}
 
-export function TodoListItem(props: TodoListItemProps) {
-  return {
-    render() {
+export const TodoListItem: ForgoNewComponentCtor<TodoListItemProps> = (
+  _props
+) => {
+  return new Component({
+    render(props) {
       return <li>{props.text}</li>;
     },
-  };
-}
+  });
+};
 
 /*
   Add a Todo Box
 */
-type AddTodoProps = {
+interface AddTodoProps {
   onAdd: (text: string) => void;
-};
+}
 
-function AddTodo(props: AddTodoProps) {
+const AddTodo: ForgoNewComponentCtor<AddTodoProps> = (props) => {
   const input: { value?: HTMLInputElement } = {};
 
-  function saveTodo() {
+  const saveTodo = () => {
     const inputEl = input.value;
     if (inputEl) {
       props.onAdd(inputEl.value);
       inputEl.value = "";
       inputEl.focus();
     }
-  }
+  };
 
   // Add the todo when enter is pressed
-  function onKeyPress(e: KeyboardEvent) {
+  const onKeyPress = (e: KeyboardEvent) => {
     if (e.key === "Enter") {
       saveTodo();
     }
-  }
+  };
 
-  return {
+  return new Component({
     render() {
       return (
         <div>
@@ -80,8 +82,8 @@ function AddTodo(props: AddTodoProps) {
         </div>
       );
     },
-  };
-}
+  });
+};
 
 function ready(fn: any) {
   if (document.readyState != "loading") {

--- a/todos/tsconfig.json
+++ b/todos/tsconfig.json
@@ -9,8 +9,9 @@
     "allowSyntheticDefaultImports": true,
     "sourceMap": true,
     "strict": true,
-    "jsx": "react-jsx",
-    "jsxImportSource": "forgo"
+    "jsx": "react",
+    "jsxFactory": "forgo.createElement",
+    "jsxFragmentFactory": "forgo.Fragment"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]
 }


### PR DESCRIPTION
These were all broken because they hadn't been updated after we stopped supporting the `react-jsx` runtime.